### PR TITLE
remember window position on close widget and  restore it on opening the widget

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -123,22 +123,31 @@ updateTimer->start(1000);
 }
 
 void MainWindow::setWindowPosition() {
-    QScreen *primaryScreen = QGuiApplication::primaryScreen();
-    QRect screenGeometry = primaryScreen->geometry();
+    QSettings settings("Nepdate", "NepdateWidget");
+    QPoint savedPos = settings.value("MainWindow/pos", QPoint(-1, -1)).toPoint();
 
-    int x = screenGeometry.left() + (screenGeometry.width() - width()) / 1.3; // Before statusbar in most cases.
-    int offsetY = 10;  // Number of pixels to move downward
-    int y = screenGeometry.bottom() - height() + offsetY;
+    if (savedPos != QPoint(-1, -1)) {
+        move(savedPos);
+    } else {
+        QScreen *primaryScreen = QGuiApplication::primaryScreen();
+        QRect screenGeometry = primaryScreen->geometry();
+
+        int x = screenGeometry.left() + (screenGeometry.width() - width()) / 1.3; // Before statusbar in most cases.
+        int offsetY = 10;  // Number of pixels to move downward
+        int y = screenGeometry.bottom() - height() + offsetY;
 
 #ifdef Q_OS_MAC
     int dockHeight = 0; //No idea how mac os handles dock
 #endif
-    move(x, y);
+        move(x, y);
+      }
 }
 
 
 MainWindow::~MainWindow()
 {
+    QSettings settings("Nepdate", "NepdateWidget");
+    settings.setValue("MainWindow/pos", this->pos());
     delete ui;
 }
 


### PR DESCRIPTION
When the widget is set to different position  than default position and closed, It does not remember the position and start to that position. This is really tedious when people want set the widget window to different position than the default position. So here, I used the QSettings  to save the position on exit and restore it on opening the widget.