### PR TITLE
change import "qrc:PanchangaCalculator.js" as Panchanga -> import "qrc:/PanchangaCalculator.js" as Panchanga

### DIFF
--- a/qml/widget.qml
+++ b/qml/widget.qml
@@ -2,7 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Window 2.15
-import "qrc:PanchangaCalculator.js" as Panchanga
+import "qrc:/PanchangaCalculator.js" as Panchanga
 import QtCore
 
 // widget.qml(main window for the small desktop widget)


### PR DESCRIPTION
Previously in qml/widget.qml
import "qrc:PanchangaCalculator.js" as Panchanga
caused this error when running the widget because of missing / after qrc:

QQmlApplicationEngine failed to load component
qrc:/qml/widget.qml:5:1: Script qrc:PanchangaCalculator.js unavailable qrc:PanchangaCalculator.js: File name case mismatch

to fix it, change it to
import "qrc:/PanchangaCalculator.js" as Panchanga